### PR TITLE
There is no argument named `n`

### DIFF
--- a/R/peak_finding.R
+++ b/R/peak_finding.R
@@ -127,7 +127,7 @@ find_strongest_peaks <- function(df,
     # plot(curr.plot.window$t, curr.plot.window$force, type="l")
 
     curr.specimen <- curr.plot.window %>%
-      slice(n=1) %>%
+      slice(1) %>%
       pull(specimen)
 
     threshold <- initial.threshold * max(curr.plot.window$force)


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`slice()` now errors if any `...` are named as this is typically an indication of some kind of typo. There is no argument named `n`, so I think you just wanted `slice(1)`

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!